### PR TITLE
Removing Author Blocks as per Quinoa PR 146

### DIFF
--- a/BuildShared.cmake
+++ b/BuildShared.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/BuildShared.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Set default value for building shared libs if none was specified
 # \date      Wed 23 Nov 2016 06:38:46 AM MST

--- a/BuildType.cmake
+++ b/BuildType.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/BuildType.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Set a default build type if none was specified
 # \date      Thu 05 May 2016 07:27:52 PM MDT

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/CodeCoverage.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Setup target for code coverage analysis
 # \date      Mon 03 Apr 2017 07:41:25 AM MDT

--- a/ConfigExecutable.cmake
+++ b/ConfigExecutable.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/ConfigExecutable.cmake
-# \author    J. Bakosi
 # \copyright 2016, Los Alamos National Security, LLC.
 # \brief     Configure Charm++ executable targets
 # \date      Tue 28 Mar 2017 01:46:10 PM MDT

--- a/ConfigureDataLayout.cmake
+++ b/ConfigureDataLayout.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/ConfigureDataLayout.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Configure data layouts
 # \date      Sat 17 Sep 2016 10:27:08 AM MDT

--- a/CppCheck.cmake
+++ b/CppCheck.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/CppCheck.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Setup target for code coverage analysis
 # \date      Tue 21 Mar 2017 11:17:17 AM MDT

--- a/DetectCodeCoverage.cmake
+++ b/DetectCodeCoverage.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/DetectCodeCoverage.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Detect prerequesites for code coverage analysis
 # \date      Fri 03 Mar 2017 11:50:24 AM MST

--- a/DetectOS.cmake
+++ b/DetectOS.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/DetectOS.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Detect operating system
 # \date      Wed 15 Jun 2016 09:14:33 AM MDT

--- a/DisallowInSourceBuilds.cmake
+++ b/DisallowInSourceBuilds.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/DisallowInSourceBuilds.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Cmake code to disallow in-source builds
 # \date      Fri 06 May 2016 06:41:32 AM MDT

--- a/FindAEC.cmake
+++ b/FindAEC.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindAEC.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find the Adaptive Entropy Coding library
 # \date      Fri 20 Jan 2017 12:18:02 PM MST

--- a/FindCartesianProduct.cmake
+++ b/FindCartesianProduct.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindCartesianProduct.cmake
-# \author    C. Junghans
 # \copyright 2016, Los Alamos National Security, LLC.
 # \brief     Find the Cartesian Product header
 # \date      Fri 20 Jan 2017 12:15:31 PM MST

--- a/FindCharm.cmake
+++ b/FindCharm.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindCharm.cmake
-# \author    C. Junghans
 # \copyright 2016, Los Alamos National Security, LLC.
 # \brief     Find the Charm++
 # \date      Fri 20 Jan 2017 12:14:50 PM MST

--- a/FindExodiff.cmake
+++ b/FindExodiff.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindExodiff.cmake
-# \author    J. Bakosi
 # \copyright 2016, Los Alamos National Security, LLC.
 # \brief     Find the Adaptive Entropy Coding library
 # \date      Fri 20 Jan 2017 12:16:07 PM MST

--- a/FindGmsh.cmake
+++ b/FindGmsh.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindGmsh.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find Gmsh
 # \date      Fri 06 May 2016 06:42:00 AM MDT

--- a/FindH5Part.cmake
+++ b/FindH5Part.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindH5Part.cmake
-# \author    C. Junghans
 # \copyright 2016, Los Alamos National Security, LLC.
 # \brief     Find the H5Part library
 # \date      Fri 20 Jan 2017 12:28:25 PM MST

--- a/FindHypre.cmake
+++ b/FindHypre.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindHypre.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find the Hypre library from LLNL
 # \date      Fri 20 Jan 2017 12:28:14 PM MST

--- a/FindLAPACKE.cmake
+++ b/FindLAPACKE.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindLAPACKE.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find the C-interface to LAPACK as well as LAPACK/BLAS
 # \date      Fri 20 Jan 2017 12:31:47 PM MST

--- a/FindLibCXX.cmake
+++ b/FindLibCXX.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindLibCXX.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find libc++
 # \date      Fri 20 Jan 2017 12:42:21 PM MST

--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindLMKL.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find the Math Kernel Library from Intel
 # \date      Thu 26 Jan 2017 02:05:50 PM MST

--- a/FindNetCDF.cmake
+++ b/FindNetCDF.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindLNetCDF.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find NetCDF
 # \date      Fri 06 May 2016 06:42:49 AM MDT

--- a/FindNumDiff.cmake
+++ b/FindNumDiff.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindNumDiff.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find NumDiff
 # \date      Mon 27 Mar 2017 08:26:37 AM MDT

--- a/FindPEGTL.cmake
+++ b/FindPEGTL.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindPEGTL.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find PEGTL
 #

--- a/FindPStreams.cmake
+++ b/FindPStreams.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindLPstreams.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find the Pstreams library
 # \date      Fri 20 Jan 2017 01:15:41 PM MST

--- a/FindPugixml.cmake
+++ b/FindPugixml.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindPugixml.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find the pugixml library
 #

--- a/FindRNGSSE2.cmake
+++ b/FindRNGSSE2.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindRNGSSE2.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find the RNGSSE2 library
 # \date      Fri 20 Jan 2017 01:27:21 PM MST

--- a/FindRandom123.cmake
+++ b/FindRandom123.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindRandom123.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find Random123
 # \date      Fri 20 Jan 2017 01:23:32 PM MST

--- a/FindTUT.cmake
+++ b/FindTUT.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindTUT.cmake
-# \author    C. Junghans
 # \copyright 2016, Los Alamos National Security, LLC.
 # \brief     Find the Template Unit Test library header
 # \date      Fri 20 Jan 2017 01:33:53 PM MST

--- a/FindTestU01.cmake
+++ b/FindTestU01.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/FindTestU01.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find the TestU01 library
 # \date      Fri 20 Jan 2017 01:29:39 PM MST

--- a/MPICompilers.cmake
+++ b/MPICompilers.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/MPICompilers.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find the MPI wrappers
 # \date      Fri 06 May 2016 06:43:41 AM MDT

--- a/TPLs.cmake
+++ b/TPLs.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/TPLs.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find the third-party libraries required to build Quinoa
 # \date      Sun 05 Mar 2017 08:56:51 PM MST

--- a/add_regression_test.cmake
+++ b/add_regression_test.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/add_regression_test.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Function used to add a regression test to the ctest test suite
 # \date      Fri 31 Mar 2017 08:10:00 AM MDT

--- a/charm.cmake
+++ b/charm.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/charm.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Function used to setup a Charm++ module
 # \date      Sat 16 Jul 2016 08:50:27 PM MDT

--- a/get_compiler_flags.cmake
+++ b/get_compiler_flags.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/get_compiler_flags.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Cmake code to get compiler flags
 # \date      Fri 06 May 2016 06:44:41 AM MDT

--- a/libstdcxx.cmake
+++ b/libstdcxx.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/libstdcxx.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Find libc++ and offer to switch between libc++ and libstdc++
 # \date      Fri 20 Jan 2017 12:39:24 PM MST

--- a/test_runner.cmake
+++ b/test_runner.cmake
@@ -1,7 +1,6 @@
 ################################################################################
 #
 # \file      cmake/test_runner.cmake
-# \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Regression test runner using the cmake scripting language
 # \date      Fri 31 Mar 2017 02:45:45 PM MDT


### PR DESCRIPTION
Removed author blocks as per quinoacomputing/quinoa#146 to follow more traditional
open source model