### PR TITLE
Revert "Add support to detect pegtl version"

### DIFF
--- a/FindPEGTL.cmake
+++ b/FindPEGTL.cmake
@@ -20,32 +20,6 @@
 #  find_package(PEGTL)
 #  include_directories(${PEGTL_INCLUDE_DIRS})
 
-function(_PEGTL_GET_VERSION _OUT_major _OUT_minor _OUT_micro _metisversion_hdr)
-    file(STRINGS ${_metisversion_hdr} _contents REGEX "#define PEGTL_VER_[A-Z]+[ \t]+")
-    if(_contents)
-        string(REGEX REPLACE ".*#define TAOCPP_PEGTL_VERSION_MAJOR[ \t]+([0-9]+).*" "\\1" ${_OUT_major} "${_contents}")
-	string(REGEX REPLACE ".*#define TAOCPP_PEGTL_VERSION_MINOR[ \t]+([0-9]+).*" "\\1" ${_OUT_minor} "${_contents}")
-	string(REGEX REPLACE ".*#define TAOCPP_PEGTL_VERSION_PATCH[ \t]+([0-9]+).*" "\\1" ${_OUT_micro} "${_contents}")
-
-        if(NOT ${_OUT_major} MATCHES "[0-9]+")
-            message(FATAL_ERROR "Version parsing failed for TAOCPP_PEGTL_VERSION_MAJOR!")
-        endif()
-        if(NOT ${_OUT_minor} MATCHES "[0-9]+")
-            message(FATAL_ERROR "Version parsing failed for TAOCPP_PEGTL_VERSION_MINOR!")
-        endif()
-        if(NOT ${_OUT_micro} MATCHES "[0-9]+")
-            message(FATAL_ERROR "Version parsing failed for TAOCPP_PEGTL_VERSION_PATCH!")
-        endif()
-
-        set(${_OUT_major} ${${_OUT_major}} PARENT_SCOPE)
-        set(${_OUT_minor} ${${_OUT_minor}} PARENT_SCOPE)
-        set(${_OUT_micro} ${${_OUT_micro}} PARENT_SCOPE)
-
-    else()
-        message(FATAL_ERROR "Include file ${_metisversion_hdr} does not exist")
-    endif()
-endfunction()
-
 # If already in cache, be silent
 if(PEGTL_INCLUDE_DIRS)
   set (PEGTL_FIND_QUIETLY TRUE)
@@ -55,18 +29,12 @@ find_path(PEGTL_INCLUDE_DIR NAMES pegtl.hpp
                             HINTS ${PEGTL_ROOT}/include
                                   $ENV{PEGTL_ROOT}/include
                             PATH_SUFFIXES tao pegtl/include/tao)
-if(PEGTL_INCLUDE_DIR)
-  _PEGTL_GET_VERSION(PEGTL_MAJOR_VERSION PEGTL_MINOR_VERSION PEGTL_PATCH_VERSION ${PEGTL_INCLUDE_DIR}/pegtl/version.hpp)
-  set(PEGTL_VERSION ${PEGTL_MAJOR_VERSION}.${PEGTL_MINOR_VERSION}.${PEGTL_PATCH_VERSION})
-else()
-  set(PEGTL_VERSION 0.0.0)
-endif()
 
 set(PEGTL_INCLUDE_DIRS ${PEGTL_INCLUDE_DIR})
 
 # Handle the QUIETLY and REQUIRED arguments and set PEGTL_FOUND to TRUE if
 # all listed variables are TRUE.
 INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(PEGTL REQUIRED_VARS PEGTL_INCLUDE_DIRS VERSION_VAR PEGTL_VERSION)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(PEGTL DEFAULT_MSG PEGTL_INCLUDE_DIRS)
 
 MARK_AS_ADVANCED(PEGTL_INCLUDE_DIRS)

--- a/TPLs.cmake
+++ b/TPLs.cmake
@@ -62,7 +62,7 @@ find_package(Pugixml REQUIRED)
 
 #### PEGTL
 set(PEGTL_ROOT ${TPL_DIR}) # prefer ours
-find_package(PEGTL 2.0.0 REQUIRED)
+find_package(PEGTL REQUIRED)
 
 #### Random123
 set(Random123_ROOT ${TPL_DIR}) # prefer ours


### PR DESCRIPTION
Reverts quinoacomputing/cmake-modules#4.

Not sure why but the gentoo docker image fails to detect PEGTL's `version.hpp`, so let's revert this until fixed.

See, e.g., https://travis-ci.org/quinoacomputing/quinoa/builds/247979770.