### PR TITLE
Mods so Charm and NetCDF are found if in TPL_DIR

### DIFF
--- a/FindCharm.cmake
+++ b/FindCharm.cmake
@@ -48,6 +48,7 @@ FIND_PROGRAM(CHARM_COMPILER
   ${CHARM_ROOT}/bin
   $ENV{CHARM_ROOT}/bin
   ${CYGWIN_INSTALL_PATH}/bin
+  ${CMAKE_INSTALL_PREFIX}/charm/bin
 )
 
 if(CHARM_COMPILER)
@@ -58,6 +59,7 @@ FIND_PATH(CHARM_INCLUDE_DIR NAMES charm.h
                             HINTS ${HINTS_CHARMINC}
                                   ${CHARM_ROOT}/include
                                   $ENV{CHARM_ROOT}/include
+                                  ${CMAKE_INSTALL_PREFIX}/charm/include
                             PATH_SUFFIXES charm)
 
 set(CHARM_INCLUDE_DIRS ${CHARM_INCLUDE_DIR})

--- a/FindNetCDF.cmake
+++ b/FindNetCDF.cmake
@@ -41,20 +41,26 @@ if (NETCDF_INCLUDES AND NETCDF_LIBRARIES)
 endif (NETCDF_INCLUDES AND NETCDF_LIBRARIES)
 
 find_path (NETCDF_INCLUDES netcdf_par.h
-           HINTS ${NETCDF_ROOT}/include
-                 ${NETCDF_DIR}/include
-                 $ENV{NETCDF_DIR}/include)
+           HINTS ${NETCDF_ROOT}
+                 ${NETCDF_DIR}
+                 $ENV{NETCDF_DIR}
+                 ${CMAKE_INSTALL_PREFIX}
+            PATH_SUFFIXES include)
 
 if(NOT BUILD_SHARED_LIBS)
   find_library (NETCDF_LIBRARIES_C NAMES libnetcdf.a
-                HINTS ${NETCDF_ROOT}/lib
-                      ${NETCDF_DIR}/lib
-                      $ENV{NETCDF_DIR}/lib)
+                HINTS ${NETCDF_ROOT}
+                      ${NETCDF_DIR}
+                      $ENV{NETCDF_DIR}
+                      ${CMAKE_INSTALL_PREFIX}
+                PATH_SUFFIXES lib)
 else()
   find_library (NETCDF_LIBRARIES_C NAMES netcdf
-                HINTS ${NETCDF_ROOT}/lib
-                      ${NETCDF_DIR}/lib
-                      $ENV{NETCDF_DIR}/lib)
+                HINTS ${NETCDF_ROOT}
+                      ${NETCDF_DIR}
+                      $ENV{NETCDF_DIR}
+                      ${CMAKE_INSTALL_PREFIX}
+                PATH_SUFFIXES lib)
 endif()
 mark_as_advanced(NETCDF_LIBRARIES_C)
 
@@ -90,7 +96,7 @@ else()
   NetCDF_check_interface (F90 netcdf.mod  netcdff)
 endif()
 
-set (NETCDF_LIBRARIES "${NetCDF_libs}" CACHE STRING "All NetCDF libraries required for interface level")
+set (NETCDF_LIBRARIES ${NetCDF_libs})
 
 # handle the QUIETLY and REQUIRED arguments and set NETCDF_FOUND to TRUE if
 # all listed variables are TRUE

--- a/FindNetCDF.cmake
+++ b/FindNetCDF.cmake
@@ -53,14 +53,14 @@ if(NOT BUILD_SHARED_LIBS)
                       ${NETCDF_DIR}
                       $ENV{NETCDF_DIR}
                       ${CMAKE_INSTALL_PREFIX}
-                PATH_SUFFIXES lib)
+                PATH_SUFFIXES lib lib64)
 else()
   find_library (NETCDF_LIBRARIES_C NAMES netcdf
                 HINTS ${NETCDF_ROOT}
                       ${NETCDF_DIR}
                       $ENV{NETCDF_DIR}
                       ${CMAKE_INSTALL_PREFIX}
-                PATH_SUFFIXES lib)
+                PATH_SUFFIXES lib lib64)
 endif()
 mark_as_advanced(NETCDF_LIBRARIES_C)
 


### PR DESCRIPTION
These changes are necessary for cmake to find these libraries already installed in `TPL_DIR` when cmake/make are run repeatedly.