### PR TITLE
Add MKL's lib path to cmake's rpath

### DIFF
--- a/FindMKL.cmake
+++ b/FindMKL.cmake
@@ -95,6 +95,10 @@ else()
 
 endif()
 
+# Add MKL library path to rpath
+get_filename_component(MKL_RPATH_DIR ${MKL_CORE_LIBRARY} DIRECTORY)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${MKL_RPATH_DIR}")
+
 # Handle the QUIETLY and REQUIRED arguments and set MKL_FOUND to TRUE if
 # all listed variables are TRUE.
 INCLUDE(FindPackageHandleStandardArgs)


### PR DESCRIPTION
For some reason cmake does not add MKL's lib path to rpath after find_library, causing the mkl libs not being found after make install.

This commit explicitly adds the MKL lib path to rpath. Thanks to @machriston for finding the bug.

See how this is used in https://github.com/quinoacomputing/quinoa/commit/726133b9dea18589aac1713e1922cc0463d98ed1.